### PR TITLE
feat: implement HTTP request handling with JSON and buffer support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,11 +30,6 @@ runs:
         WORKFLOWREF: ${{ github.workflow_ref }}
         REPO: ${{ github.repository }}
       run: |
-        npm run ci -- --gh-token "$GITHUB_TOKEN" --package "$PACKAGE" --dist-tag "$DISTTAG" --workflow-ref "$WORKFLOWREF" --ci-workspace-path "$CI_WORKSPACE_PATH" --ci-action-path "$CI_ACTION_PATH" --repo "$REPO"
+        npm run ci
       shell: bash
       working-directory: ${{ github.action_path }}
-    - name: Remember the dist tag data
-      uses: actions/upload-artifact@v4
-      with:
-        name: dist-tag
-        path: /tmp/dist-tag.json

--- a/index.ts
+++ b/index.ts
@@ -1,59 +1,140 @@
-import * as Commander from 'commander'
 import * as Actions from '@actions/core'
+import * as ESToolkit from 'es-toolkit'
+import * as Fs from 'node:fs/promises'
 import * as Os from 'node:os'
-import * as Fs from 'node:fs'
-import PLimit from 'p-limit'
-import { RequestNpmPackageMetaData } from './sources/npm-api.js'
+import * as Zod from 'zod'
+import { FilterArgumentsForOptions, ParseArgumentsAndOptions } from '@typescriptprime/parsing'
 import { HistoryManager } from './sources/github.js'
-import { PurgeRequestManager } from './sources/requests.js'
 import { FileManager } from './sources/file.js'
+import { RequestNpmPackageMetaData } from './sources/npm-api.js'
+import { PurgeRequestManager } from './sources/requests.js'
 
-Actions.info(`Running on ${Os.cpus()[0].model} with ${Os.cpus().length} threads/vCPUs.`)
+const RawCLIOptionsSchema = Zod.strictObject({
+  ghToken: Zod.string().optional(),
+  package: Zod.string().optional(),
+  ciWorkspacePath: Zod.string().optional(),
+  ciActionPath: Zod.string().optional(),
+  workflowRef: Zod.string().optional(),
+  distTag: Zod.string().optional(),
+  repo: Zod.string().optional()
+}).partial()
 
-const Program = new Commander.Command()
+type IRawCLIOptions = Zod.infer<typeof RawCLIOptionsSchema>
 
-// Set options.
-Program.option('--gh-token <TOKEN>', 'GitHub token', '')
-	.option('--package <package>', 'A npm package. eg: owner/repo', '')
-	.option('--ci-workspace-path <PATH>', 'A path to the CI workspace.', '')
-	.option('--ci-action-path <PATH>', 'A path to the CI action.', '')
-	.option('--workflow-ref <WORKFLOW_REF>', 'A GitHub workflow ref. eg: refs/heads/master', '')
-	.option('--dist-tag <DIST_TAG>', 'A npm dist-tag. eg: latest', '')
-	.option('--repo <REPO>', 'A GitHub repository. eg: owner/repo', '')
-
-// Initialize Input of the options and export them.
-Program.parse()
-
-const Options = Program.opts() as {
-	// eslint-disable-next-line @typescript-eslint/naming-convention
-	ghToken: string
-	// eslint-disable-next-line @typescript-eslint/naming-convention
-	package: string
-	// eslint-disable-next-line @typescript-eslint/naming-convention
-	ciWorkspacePath: string
-	// eslint-disable-next-line @typescript-eslint/naming-convention
-	ciActionPath: string,
-	// eslint-disable-next-line @typescript-eslint/naming-convention
-	workflowRef: string
-	// eslint-disable-next-line @typescript-eslint/naming-convention
-	distTag: string
-	// eslint-disable-next-line @typescript-eslint/naming-convention
-	repo: string
+type IRuntimeOptions = {
+  GhToken: string
+  Package: string
+  CiWorkspacePath: string
+  WorkflowRef: string
+  DistTag: string
+  Repo: string
 }
 
-const CurrrentTags = (await RequestNpmPackageMetaData(Options.package))['dist-tags']
-Fs.writeFileSync('/tmp/dist-tag.json', JSON.stringify(CurrrentTags))
-const OlderTags = await new HistoryManager({ Repo: Options.repo, GitHubToken: Options.ghToken, WorkflowRef: Options.workflowRef }).RequestHistory()
-
-const PLimitInstance = PLimit(Os.cpus().length)
-const PLimitJobs: Promise<void>[] = []
-for (const TargetTag of Options.distTag.split(' ')) {
-	PLimitJobs.push(PLimitInstance(async () => {
-		const ChangedFiles = await new FileManager(Options.package, { A: CurrrentTags[TargetTag], B: OlderTags === null ? undefined : OlderTags[TargetTag] }, `${Options.ciWorkspacePath}/${TargetTag}`).Union()
-		const PurgeRequestManagerInstance = new PurgeRequestManager(Options.package)
-		PurgeRequestManagerInstance.AddURLs(ChangedFiles, TargetTag)
-		PurgeRequestManagerInstance.Start()
-	}))
+function ResolveStringOption(...Values: Array<string | boolean | undefined>): string {
+  return Values.find((Value): Value is string => typeof Value === 'string' && Value.length > 0) ?? ''
 }
 
-await Promise.all(PLimitJobs)
+function RequireStringOption(Value: string, OptionName: string): string {
+  if (Value.length === 0) {
+    throw new Error(OptionName + ' is required')
+  }
+
+  return Value
+}
+
+async function ResolveOptions(): Promise<IRuntimeOptions> {
+  const ParsedCLIArguments = await ParseArgumentsAndOptions<Record<string, string | boolean>>(
+    FilterArgumentsForOptions(process.argv),
+    {
+      NamingConvention: ESToolkit.camelCase
+    }
+  )
+
+  const ParsedCLIOptions = RawCLIOptionsSchema.parse(ParsedCLIArguments.Options) as IRawCLIOptions
+
+  return {
+    GhToken: ResolveStringOption(
+      ParsedCLIOptions.ghToken,
+      process.env.GITHUB_TOKEN,
+      process.env.GH_TOKEN
+    ),
+    Package: RequireStringOption(
+      ResolveStringOption(ParsedCLIOptions.package, process.env.PACKAGE),
+      '--package or PACKAGE'
+    ),
+    CiWorkspacePath: ResolveStringOption(
+      ParsedCLIOptions.ciWorkspacePath,
+      process.env.CI_WORKSPACE_PATH,
+      process.cwd()
+    ),
+    WorkflowRef: ResolveStringOption(
+      ParsedCLIOptions.workflowRef,
+      process.env.WORKFLOW_REF,
+      process.env.WORKFLOWREF
+    ),
+    DistTag: RequireStringOption(
+      ResolveStringOption(
+        ParsedCLIOptions.distTag,
+        process.env.DIST_TAG,
+        process.env.DISTTAG
+      ),
+      '--dist-tag or DISTTAG'
+    ),
+    Repo: RequireStringOption(
+      ResolveStringOption(
+        ParsedCLIOptions.repo,
+        process.env.REPO,
+        process.env.GITHUB_REPOSITORY
+      ),
+      '--repo or REPO'
+    )
+  }
+}
+
+async function Main(): Promise<void> {
+  const Options = await ResolveOptions()
+  const CPUModel = Os.cpus()[0]?.model ?? 'Unknown CPU'
+
+  Actions.info('Running on ' + CPUModel + ' with ' + Os.availableParallelism() + ' threads/vCPUs.')
+
+  const CurrentTags = (await RequestNpmPackageMetaData(Options.Package))['dist-tags']
+  await Fs.writeFile('/tmp/dist-tag.json', JSON.stringify(CurrentTags))
+
+  const OlderTags = await new HistoryManager({
+    Repo: Options.Repo,
+    GitHubToken: Options.GhToken,
+    WorkflowRef: Options.WorkflowRef
+  }).RequestHistory()
+
+  const TargetTags = Options.DistTag.split(/\s+/).filter(Boolean)
+
+  await Promise.all(TargetTags.map(async (TargetTag) => {
+    const CurrentVersion = CurrentTags[TargetTag]
+
+    if (typeof CurrentVersion !== 'string') {
+      throw new Error('dist-tag not found: ' + TargetTag)
+    }
+
+    const PreviousVersion = OlderTags?.[TargetTag]
+    const Versions = PreviousVersion === CurrentVersion
+      ? { A: CurrentVersion }
+      : { A: CurrentVersion, B: PreviousVersion }
+
+    const ChangedFiles = await new FileManager(
+      Options.Package,
+      Versions,
+      Options.CiWorkspacePath + '/' + TargetTag
+    ).Union()
+
+    if (ChangedFiles.length === 0) {
+      Actions.info('No files changed for dist-tag ' + TargetTag)
+      return
+    }
+
+    const PurgeRequestManagerInstance = new PurgeRequestManager(Options.Package)
+    PurgeRequestManagerInstance.AddURLs(ChangedFiles, TargetTag)
+    await PurgeRequestManagerInstance.Start()
+  }))
+}
+
+await Main()

--- a/package.json
+++ b/package.json
@@ -13,28 +13,28 @@
   "type": "module",
   "scripts": {
     "ci": "tsx index.ts",
-    "lint": "tsc --noEmit && eslint ."
+    "lint": "tsc --noEmit && eslint .",
+    "test": "node --import tsx --test tests/**/*.test.ts"
   },
   "dependencies": {
-    "@actions/core": "^1.11.1",
-    "@octokit/rest": "^22.0.0",
-    "@types/node": "^22.18.6",
-    "commander": "^14.0.1",
-    "es-toolkit": "^1.39.10",
-    "got": "^14.4.9",
-    "luxon": "^3.7.2",
-    "p-limit": "^7.1.1",
-    "tar": "^7.4.3",
-    "tsx": "^4.20.5",
-    "typescript": "^5.9.2",
-    "unzipper": "^0.12.3"
+    "@actions/core": "^3.0.0",
+    "@octokit/rest": "^22.0.1",
+    "@types/node": "^24.12.2",
+    "@typescriptprime/parsing": "^2.0.1",
+    "@typescriptprime/securereq": "^2.0.0",
+    "es-toolkit": "^1.45.1",
+    "piscina": "^5.1.4",
+    "tar": "^7.5.13",
+    "temporal-kit": "^0.2.7",
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.2",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@types/luxon": "^3.7.1",
-    "@types/npm-registry-fetch": "^8.0.8",
     "@types/semver": "^7.7.1",
-    "@types/unzipper": "^0.10.11",
-    "eslint": "^9.35.0",
-    "typescript-eslint": "^8.44.0"
+    "@typescript-eslint/eslint-plugin": "^8.58.0",
+    "@typescript-eslint/parser": "^8.58.0",
+    "eslint": "^10.2.0",
+    "typescript-eslint": "^8.58.0"
   }
 }

--- a/sources/file.ts
+++ b/sources/file.ts
@@ -1,72 +1,101 @@
-import got from 'got'
-import PLimit from 'p-limit'
-import * as Tar from 'tar'
 import * as ESToolkit from 'es-toolkit'
 import * as Fs from 'node:fs'
-import * as Os from 'node:os'
+import * as FsPromises from 'node:fs/promises'
+import * as Path from 'node:path'
+import * as Tar from 'tar'
+import { RequestBuffer } from './http.js'
+
+export type IFileManagerOptions = {
+  RegistryBaseURL?: string
+}
 
 export class FileManager {
-  private NpmRepo: string = null
-  private Repo: string = null
-  private Versions: { A: string, B?: string } = null
-  private WorkPath: string = null
+  private readonly NpmRepo: string
+  private readonly Repo: string
+  private readonly Versions: { A: string, B?: string }
+  private readonly WorkPath: string
+  private readonly RegistryBaseURL: string
 
-  constructor(Repo: string, Versions: { A: string, B?: string }, WorkPath: string) {
+  constructor(
+    Repo: string,
+    Versions: { A: string, B?: string },
+    WorkPath: string,
+    Options: IFileManagerOptions = {}
+  ) {
     this.NpmRepo = Repo
-    this.Repo = typeof Repo.split('/')[1] === 'undefined' ? Repo : Repo.split('/')[1]
+    this.Repo = Repo.includes('/') ? Repo.split('/').at(-1) ?? Repo : Repo
     this.Versions = Versions
     this.WorkPath = WorkPath
+    this.RegistryBaseURL = Options.RegistryBaseURL ?? 'https://registry.npmjs.org/'
   }
 
-  private async DownloadRepoVersion() {
-    const PLimitInstance = PLimit(Os.cpus().length)
-    const PLimitJobs: Promise<void>[] = []
-    for (const Version of [this.Versions.A, this.Versions.B].filter(Item => typeof Item !== 'undefined')) {
-      PLimitJobs.push(PLimitInstance(async () => {
-        const TarFile = await got(`https://registry.npmjs.org/${this.NpmRepo}/-/${this.Repo}-${Version}.tgz`, {
-          https: {
-            minVersion: 'TLSv1.2',
-            maxVersion: 'TLSv1.2',
-            ciphers: 'ECDHE-ECDSA-AES256-GCM-SHA384;ECDHE-ECDSA-CHACHA20-POLY1305'
-          },
-          http2: true,
-          headers: {
-            'user-agent': 'jsdelivr-purge-npm'
-          }
-        }).buffer()
-        Fs.mkdirSync(this.WorkPath, { recursive: true })
-        Fs.writeFileSync(`${this.WorkPath}/${this.Repo}-${Version}.tgz`, TarFile)
-        Fs.mkdirSync(`${this.WorkPath}/${this.Repo}-${Version}`, { recursive: true })
-        await Tar.extract({ file: `${this.WorkPath}/${this.Repo}-${Version}.tgz`, cwd: `${this.WorkPath}/${this.Repo}-${Version}` })
-        Fs.rmSync(`${this.WorkPath}/${this.Repo}-${Version}.tgz`)
-      }))
+  private EnsureTrailingSlash(Value: string): string {
+    return Value.endsWith('/') ? Value : Value + '/'
+  }
+
+  private EncodePackageNameForRegistry(PackageName: string): string {
+    return PackageName.replaceAll('/', '%2F')
+  }
+
+  private CreateTarballURL(Version: string): URL {
+    return new URL(
+      this.EnsureTrailingSlash(this.RegistryBaseURL) + this.EncodePackageNameForRegistry(this.NpmRepo) + '/-/' + this.Repo + '-' + Version + '.tgz'
+    )
+  }
+
+  private GetTargetVersions(): string[] {
+    return [...new Set([this.Versions.A, this.Versions.B].filter((Item): Item is string => typeof Item === 'string'))]
+  }
+
+  private async DownloadRepoVersion(Version: string): Promise<void> {
+    const TarballBuffer = await RequestBuffer(this.CreateTarballURL(Version))
+    const TarballPath = Path.join(this.WorkPath, this.Repo + '-' + Version + '.tgz')
+    const ExtractPath = Path.join(this.WorkPath, this.Repo + '-' + Version)
+
+    await FsPromises.mkdir(this.WorkPath, { recursive: true })
+    await FsPromises.writeFile(TarballPath, TarballBuffer)
+    await FsPromises.mkdir(ExtractPath, { recursive: true })
+    await Tar.extract({ file: TarballPath, cwd: ExtractPath })
+    await FsPromises.rm(TarballPath)
+  }
+
+  private ToPackageRelativePath(SourcePath: string, FilePath: string): string {
+    return Path.relative(Path.join(SourcePath, 'package'), FilePath).split(Path.sep).join('/')
+  }
+
+  private UnionRepoFiles(): string[] {
+    const RepoARoot = Path.join(this.WorkPath, this.Repo + '-' + this.Versions.A)
+    const RepoAFiles = ListAllFiles(RepoARoot).map((Item) => this.ToPackageRelativePath(RepoARoot, Item))
+
+    if (typeof this.Versions.B === 'undefined') {
+      return RepoAFiles
     }
-    await Promise.all(PLimitJobs)
+
+    const RepoBRoot = Path.join(this.WorkPath, this.Repo + '-' + this.Versions.B)
+    const RepoBFiles = ListAllFiles(RepoBRoot).map((Item) => this.ToPackageRelativePath(RepoBRoot, Item))
+
+    return ESToolkit.union(RepoAFiles, RepoBFiles)
   }
 
-  private UnionRepoFiles() {
-    const RepoAFiles = ListAllFiles(`${this.WorkPath}/${this.Repo}-${this.Versions.A}`).map(Item => Item.replace(`${this.WorkPath}/${this.Repo}-${this.Versions.A}/package/`, ''))
-    if (typeof this.Versions.B !== 'undefined') {
-      const RepoBFiles = ListAllFiles(`${this.WorkPath}/${this.Repo}-${this.Versions.B}`).map(Item => Item.replace(`${this.WorkPath}/${this.Repo}-${this.Versions.B}/package/`, ''))
-      return ESToolkit.union(RepoAFiles, RepoBFiles)
-    }
-    return RepoAFiles
-  }
-
-  async Union() {
-    await this.DownloadRepoVersion()
+  async Union(): Promise<string[]> {
+    await Promise.all(this.GetTargetVersions().map((Version) => this.DownloadRepoVersion(Version)))
     return this.UnionRepoFiles()
   }
 }
 
-function ListAllFiles(SourcePath: string) {
-  let Files: string[] = []
+function ListAllFiles(SourcePath: string): string[] {
+  const Files: string[] = []
+
   for (const Current of Fs.readdirSync(SourcePath)) {
-    if (Fs.statSync(`${SourcePath}/${Current}`).isDirectory()) {
-      Files.push(...ListAllFiles(`${SourcePath}/${Current}`))
-    } else {
-      Files.push(`${SourcePath}/${Current}`)
+    const CurrentPath = Path.join(SourcePath, Current)
+
+    if (Fs.statSync(CurrentPath).isDirectory()) {
+      Files.push(...ListAllFiles(CurrentPath))
+      continue
     }
+
+    Files.push(CurrentPath)
   }
+
   return Files
 }

--- a/sources/github.ts
+++ b/sources/github.ts
@@ -1,62 +1,138 @@
 import * as GitHub from '@octokit/rest'
-import * as Luxon from 'luxon'
-import * as Unzipper from 'unzipper'
-import got from 'got'
+import * as Zod from 'zod'
+import { Temporal } from 'temporal-kit/polyfilled'
+import { RequestBuffer } from './http.js'
+import { ReadTextFromZipArchive } from './zip.js'
+
+const WorkflowRunsSchema = Zod.strictObject({
+  workflow_runs: Zod.array(Zod.strictObject({
+    id: Zod.number(),
+    status: Zod.string().nullable(),
+    conclusion: Zod.string().nullable(),
+    updated_at: Zod.string()
+  }))
+})
+
+const WorkflowArtifactsSchema = Zod.strictObject({
+  artifacts: Zod.array(Zod.strictObject({
+    name: Zod.string(),
+    archive_download_url: Zod.string()
+  }))
+})
+
+const HistoryDataSchema = Zod.record(Zod.string(), Zod.string())
+
+type IWorkflowRun = Zod.infer<typeof WorkflowRunsSchema>['workflow_runs'][number]
 
 export type IHistoryManagerDataJSON = Record<string, string>
 
+export interface IHistoryManagerGitHubClient {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  actions: {
+    listWorkflowRunsForRepo(Parameters: Record<string, string>): Promise<Record<string, unknown>>
+    listWorkflowRunArtifacts(Parameters: Record<string, string | number>): Promise<Record<string, unknown>>
+  }
+}
+
 export class HistoryManager {
-  private GitHubInstance: InstanceType<typeof GitHub.Octokit> = null
+  private readonly GitHubInstance: IHistoryManagerGitHubClient
 
-  constructor(private readonly Config: { Repo: string, GitHubToken: string, WorkflowRef: string }) {
-    this.GitHubInstance = new GitHub.Octokit({ auth: this.Config.GitHubToken })
+  constructor(
+    private readonly Config: { Repo: string, GitHubToken: string, WorkflowRef: string },
+    Dependencies: { GitHubClient?: IHistoryManagerGitHubClient } = {}
+  ) {
+    this.GitHubInstance = Dependencies.GitHubClient ?? new GitHub.Octokit({
+      auth: this.Config.GitHubToken
+    }) as unknown as IHistoryManagerGitHubClient
   }
 
-  private async ListHistory() {
+  private GetRepoCoordinate(): { Owner: string, Repo: string } {
+    const [Owner, Repo] = this.Config.Repo.split('/')
+
+    if (typeof Owner !== 'string' || typeof Repo !== 'string') {
+      throw new Error('Invalid repository coordinate: ' + this.Config.Repo)
+    }
+
+    return { Owner, Repo }
+  }
+
+  private GetWorkflowID(): string | null {
+    if (this.Config.WorkflowRef.length === 0) {
+      return null
+    }
+
+    const WorkflowPath = this.Config.WorkflowRef.split('@')[0] ?? this.Config.WorkflowRef
+    return WorkflowPath.split('/').at(-1) ?? null
+  }
+
+  private SortWorkflowRunsByUpdatedAt(Runs: IWorkflowRun[]): IWorkflowRun[] {
+    return Runs.toSorted((RunA, RunB) => Temporal.Instant.compare(
+      Temporal.Instant.from(RunB.updated_at),
+      Temporal.Instant.from(RunA.updated_at)
+    ))
+  }
+
+  private async GetLatestSuccessfulWorkflowRunID(): Promise<number | null> {
+    const WorkflowID = this.GetWorkflowID()
+
+    if (WorkflowID === null) {
+      return null
+    }
+
+    const { Owner, Repo } = this.GetRepoCoordinate()
     const GHResponseRuns = await this.GitHubInstance.actions.listWorkflowRunsForRepo({
-      owner: this.Config.Repo.split('/')[0],
-      repo: this.Config.Repo.split('/')[1],
-      workflow_id: this.Config.WorkflowRef
+      owner: Owner,
+      repo: Repo,
+      workflow_id: WorkflowID
     })
+
+    const WorkflowRuns = WorkflowRunsSchema.parse(GHResponseRuns.data).workflow_runs
+      .filter((Run) => Run.status === 'completed' && Run.conclusion === 'success')
+
+    return this.SortWorkflowRunsByUpdatedAt(WorkflowRuns)[0]?.id ?? null
+  }
+
+  private async GetLatestHistoryArtifactURL(): Promise<string | null> {
+    const RunID = await this.GetLatestSuccessfulWorkflowRunID()
+
+    if (RunID === null) {
+      return null
+    }
+
+    const { Owner, Repo } = this.GetRepoCoordinate()
     const GHResponseArtifacts = await this.GitHubInstance.actions.listWorkflowRunArtifacts({
-      owner: this.Config.Repo.split('/')[0],
-      repo: this.Config.Repo.split('/')[1],
-      run_id: GHResponseRuns.data.workflow_runs.filter(Run => Run.status === 'completed' && Run.conclusion === 'success')
-        .sort((RunA, RunB) => Luxon.DateTime.fromISO(RunA.updated_at).toMillis() - Luxon.DateTime.fromISO(RunB.updated_at).toMillis())[0].id
+      owner: Owner,
+      repo: Repo,
+      run_id: RunID
     })
-    return GHResponseArtifacts.data.artifacts.map((Artifact) => Artifact.archive_download_url)
+
+    const Artifacts = WorkflowArtifactsSchema.parse(GHResponseArtifacts.data).artifacts
+    return Artifacts.find((Artifact) => Artifact.name === 'dist-tag')?.archive_download_url ?? null
   }
 
-  private async CheckWorkflowRunExist() {
-    const GHResponseRuns = await this.GitHubInstance.actions.listWorkflowRunsForRepo({
-      owner: this.Config.Repo.split('/')[0],
-      repo: this.Config.Repo.split('/')[1],
-      workflow_id: this.Config.WorkflowRef,
-      status: 'completed',
-      conclusion: 'success'
-    })
-    return GHResponseRuns.data.total_count > 0
-  }
+  async RequestHistory(): Promise<IHistoryManagerDataJSON | null> {
+    if (this.Config.GitHubToken.length === 0) {
+      return null
+    }
 
-  async RequestHistory() {
-    if (!await this.CheckWorkflowRunExist()) {
+    const HistoryURLString = await this.GetLatestHistoryArtifactURL()
+
+    if (HistoryURLString === null) {
       return null
     }
-    const HistoryURL = await this.ListHistory()[0]
-    if (typeof HistoryURL === 'undefined') {
-      return null
-    }
-    const HistoryCompressedBuffer = await got(HistoryURL, {
-      https: {
-        minVersion: 'TLSv1.3',
-        ciphers: 'TLS_AES_256_GCM_SHA384;TLS_CHACHA20_POLY1305_SHA256'
-      },
-      http2: true,
-      headers: {
-        'user-agent': 'jsdelivr-purge-npm'
+
+    const HistoryArchiveBuffer = await RequestBuffer(new URL(HistoryURLString), {
+      FollowRedirects: true,
+      HttpHeaders: {
+        authorization: 'Bearer ' + this.Config.GitHubToken
       }
-    }).buffer()
-    const HistoryData = (await Unzipper.Open.buffer(HistoryCompressedBuffer)).files.find(FilePara => FilePara.path.includes('dist-tag.json'))
-    return (await HistoryData.buffer()).toString() as unknown as IHistoryManagerDataJSON
+    })
+
+    const HistoryJSON = ReadTextFromZipArchive(
+      HistoryArchiveBuffer,
+      (EntryName) => EntryName.endsWith('dist-tag.json')
+    )
+
+    return HistoryDataSchema.parse(JSON.parse(HistoryJSON))
   }
 }

--- a/sources/http.ts
+++ b/sources/http.ts
@@ -1,0 +1,69 @@
+import { SimpleSecureReq } from '@typescriptprime/securereq'
+import type {
+  ExpectedAsKey,
+  ExpectedAsMap,
+  HTTPSRequestOptions,
+  HTTPSResponse
+} from '@typescriptprime/securereq'
+import * as Zod from 'zod'
+
+function CreateDefaultHeaders(HttpHeaders: Record<string, string> = {}): Record<string, string> {
+  return {
+    'user-agent': 'jsdelivr-purge-npm',
+    ...HttpHeaders
+  }
+}
+
+function CreateRequestOptions<E extends ExpectedAsKey>(
+  URLInstance: URL,
+  Options: HTTPSRequestOptions<E> & { ExpectedAs: E }
+): HTTPSRequestOptions<E> & { ExpectedAs: E } {
+  return {
+    ...Options,
+    HttpHeaders: CreateDefaultHeaders(Options.HttpHeaders),
+    TLS: {
+      IsHTTPSEnforced: URLInstance.protocol === 'https:',
+      ...Options.TLS
+    }
+  }
+}
+
+function EnsureSuccessStatusCode<T>(Response: HTTPSResponse<T>, URLInstance: URL): void {
+  if (Response.StatusCode < 200 || Response.StatusCode >= 300) {
+    throw new Error('Request failed for ' + URLInstance.toString() + ' with status ' + Response.StatusCode)
+  }
+}
+
+export async function RequestExpectedAs<E extends ExpectedAsKey>(
+  URLInstance: URL,
+  Options: HTTPSRequestOptions<E> & { ExpectedAs: E }
+): Promise<HTTPSResponse<ExpectedAsMap[E]>> {
+  return SimpleSecureReq.Request(URLInstance, CreateRequestOptions(URLInstance, Options))
+}
+
+export async function RequestJSON<T extends Zod.ZodType>(
+  URLInstance: URL,
+  Schema: T,
+  Options: Omit<HTTPSRequestOptions<'JSON'>, 'ExpectedAs'> = {}
+): Promise<Zod.infer<T>> {
+  const Response = await RequestExpectedAs(URLInstance, {
+    ...Options,
+    ExpectedAs: 'JSON'
+  })
+
+  EnsureSuccessStatusCode(Response, URLInstance)
+  return Schema.parseAsync(Response.Body)
+}
+
+export async function RequestBuffer(
+  URLInstance: URL,
+  Options: Omit<HTTPSRequestOptions<'ArrayBuffer'>, 'ExpectedAs'> = {}
+): Promise<Buffer> {
+  const Response = await RequestExpectedAs(URLInstance, {
+    ...Options,
+    ExpectedAs: 'ArrayBuffer'
+  })
+
+  EnsureSuccessStatusCode(Response, URLInstance)
+  return Buffer.from(Response.Body)
+}

--- a/sources/npm-api.ts
+++ b/sources/npm-api.ts
@@ -1,43 +1,51 @@
-import * as Got from 'got'
+import * as Zod from 'zod'
+import { RequestJSON } from './http.js'
 
-export interface INpmPackageMetaData {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  name: string
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  'dist-tags': Record<'latest' | string, TNpmTag>,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  versions: Record<TNpmTag | string, TNpmPackageVersionMeta>
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  time: Record<'created' | 'modified' | string, string>
-}
+const NpmPackageVersionMetaSchema = Zod.strictObject({
+  name: Zod.string(),
+  version: Zod.string(),
+  dist: Zod.strictObject({
+    shasum: Zod.string(),
+    tarball: Zod.string(),
+    integrity: Zod.string()
+  })
+})
 
+const NpmPackageMetaDataSchema = Zod.strictObject({
+  name: Zod.string(),
+  'dist-tags': Zod.record(Zod.string(), Zod.string()),
+  versions: Zod.record(Zod.string(), NpmPackageVersionMetaSchema),
+  time: Zod.record(Zod.string(), Zod.string())
+})
+
+export type INpmPackageMetaData = Zod.infer<typeof NpmPackageMetaDataSchema>
 export type TNpmTag = string
+export type TNpmPackageVersionMeta = Zod.infer<typeof NpmPackageVersionMetaSchema>
 
-export type TNpmPackageVersionMeta = {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  name: string
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  version: string
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  dist: {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    shasum: string,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    tarball: string,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    integrity: string
-  }
+export type INpmAPIOptions = {
+  RegistryBaseURL?: string
 }
 
-export async function RequestNpmPackageMetaData(PackageName: string): Promise<INpmPackageMetaData> {
-  const GotResponse = await Got.got(`https://registry.npmjs.org/${PackageName}`, {
-    https: {
-      minVersion: 'TLSv1.2',
-      maxVersion: 'TLSv1.2',
-      ciphers: 'ECDHE-ECDSA-AES256-GCM-SHA384;ECDHE-ECDSA-CHACHA20-POLY1305'
-    },
-    http2: true
-  }).json()
-  return GotResponse as INpmPackageMetaData
+function EnsureTrailingSlash(Value: string): string {
+  return Value.endsWith('/') ? Value : Value + '/'
 }
 
+function EncodePackageNameForRegistry(PackageName: string): string {
+  return PackageName.replaceAll('/', '%2F')
+}
+
+function CreateRegistryURL(PackageName: string, RegistryBaseURL = 'https://registry.npmjs.org/'): URL {
+  return new URL(
+    EnsureTrailingSlash(RegistryBaseURL) + EncodePackageNameForRegistry(PackageName)
+  )
+}
+
+export async function RequestNpmPackageMetaData(
+  PackageName: string,
+  Options: INpmAPIOptions = {}
+): Promise<INpmPackageMetaData> {
+  return RequestJSON(
+    CreateRegistryURL(PackageName, Options.RegistryBaseURL),
+    NpmPackageMetaDataSchema
+  )
+}

--- a/sources/requests.ts
+++ b/sources/requests.ts
@@ -1,139 +1,214 @@
-import got from 'got'
 import * as Actions from '@actions/core'
-import * as Os from 'node:os'
-import PLimit from 'p-limit'
 import * as ESToolkit from 'es-toolkit'
+import * as Os from 'node:os'
+import * as Zod from 'zod'
+import { RequestJSON } from './http.js'
 
-type CDNStatusResponseType = {
-	// eslint-disable-next-line @typescript-eslint/naming-convention
-	id: string;
-	// eslint-disable-next-line @typescript-eslint/naming-convention
-	status: 'pending' | 'finished' | 'failed';
-	// eslint-disable-next-line @typescript-eslint/naming-convention
-	paths: Record<string, {
-		// eslint-disable-next-line @typescript-eslint/naming-convention
-		throttled: boolean;
-		// eslint-disable-next-line @typescript-eslint/naming-convention
-		providers: {
-			CF: boolean;
-			FY: boolean;
-		};
-	}>;
-}
+const CDNStatusResponseSchema = Zod.strictObject({
+  id: Zod.string(),
+  status: Zod.enum(['pending', 'finished', 'failed']),
+  paths: Zod.record(Zod.string(), Zod.strictObject({
+    throttled: Zod.boolean(),
+    providers: Zod.strictObject({
+      CF: Zod.boolean(),
+      FY: Zod.boolean()
+    })
+  }))
+})
 
-type CDNPostResponseType = {
-	// eslint-disable-next-line @typescript-eslint/naming-convention
-	id: string;
-	// eslint-disable-next-line @typescript-eslint/naming-convention
-	status: 'pending' | 'finished' | 'failed';
-	// eslint-disable-next-line @typescript-eslint/naming-convention
-	timestamp: string;
-}
+const CDNPostResponseSchema = Zod.strictObject({
+  id: Zod.string(),
+  status: Zod.enum(['pending', 'finished', 'failed']),
+  timestamp: Zod.string()
+})
 
-type CDNPostRequestType = {
-	// eslint-disable-next-line @typescript-eslint/naming-convention
-	path: string[];
-}
+type CDNStatusResponseType = Zod.infer<typeof CDNStatusResponseSchema>
+type CDNPostResponseType = Zod.infer<typeof CDNPostResponseSchema>
 
 type RemainingFilenamesArrayType = {
-	Filename: string;
-	Tag: string;
+  Filename: string
+  Tag: string
 }
 
-async function GetCDNResponse(ID: string): Promise<CDNStatusResponseType> {
-	const ResponseRaw: CDNStatusResponseType = await got(`https://purge.jsdelivr.net/status/${ID}`, {
-		https: {
-			minVersion: 'TLSv1.3',
-			ciphers: 'TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256'
-		},
-		http2: true,
-		headers: {
-			'user-agent': 'jsdelivr-purge-npm'
-		}
-	}).json()
-
-	for (const [Key, Value] of Object.entries(ResponseRaw.paths)) {
-		if (Value.throttled) {
-			Actions.warning(`Throttled: ${Key}`)
-		}
-	}
-
-	Actions.startGroup(`GetCDNResponse called: ${ID}`)
-	Actions.info(JSON.stringify(ResponseRaw))
-	Actions.endGroup()
-	return ResponseRaw
+export type IPurgeRequestManagerOptions = {
+  BaseURL?: string
+  PollIntervalMs?: number
+  Concurrency?: number
 }
 
-async function PostPurgeRequest(Repo: string, Tag: string[], Filenames: string[]): Promise<CDNPostResponseType> {
-	const ResponseRaw: CDNPostResponseType = await got.post('https://purge.jsdelivr.net/', {
-		headers: {
-			'cache-control': 'no-cache',
-			'user-agent': 'jsdelivr-purge'
-		},
-		json: {
-			path: new Array(Filenames.length).fill(null, 0, Filenames.length).map((Filename, Index) => `/npm/${Repo}@${Tag[Index]}/${Filenames[Index]}`)
-		} satisfies CDNPostRequestType,
-		https: {
-			minVersion: 'TLSv1.3',
-			ciphers: 'TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256'
-		},
-		http2: true
-	}).json()
-	Actions.startGroup(`PostPurgeRequest called: ${ResponseRaw.id}`)
-	Actions.info(JSON.stringify(ResponseRaw))
-	Actions.endGroup()
-	return ResponseRaw
+function EnsureTrailingSlash(Value: string): string {
+  return Value.endsWith('/') ? Value : Value + '/'
+}
+
+function CreateBaseURL(BaseURL = 'https://purge.jsdelivr.net/'): URL {
+  return new URL(EnsureTrailingSlash(BaseURL))
+}
+
+export function CreatePurgePaths(Repo: string, Tag: string[], Filenames: string[]): string[] {
+  return Filenames.map((Filename, Index) => '/npm/' + Repo + '@' + Tag[Index] + '/' + Filename)
+}
+
+async function Sleep(DurationMs: number): Promise<void> {
+  await new Promise((Resolve) => {
+    setTimeout(Resolve, DurationMs)
+  })
+}
+
+async function RunWithConcurrency<T>(
+  Items: T[],
+  Concurrency: number,
+  Handler: (Item: T) => Promise<void>
+): Promise<void> {
+  let CurrentIndex = 0
+  const WorkerCount = Math.min(Math.max(1, Concurrency), Items.length)
+
+  await Promise.all(Array.from({ length: WorkerCount }, async () => {
+    while (CurrentIndex < Items.length) {
+      const Item = Items[CurrentIndex]
+      CurrentIndex += 1
+
+      if (typeof Item === 'undefined') {
+        continue
+      }
+
+      await Handler(Item)
+    }
+  }))
+}
+
+async function GetCDNResponse(ID: string, BaseURL: URL): Promise<CDNStatusResponseType> {
+  const ResponseParsed = await RequestJSON(
+    new URL('status/' + ID, BaseURL),
+    CDNStatusResponseSchema
+  )
+
+  for (const [Key, Value] of Object.entries(ResponseParsed.paths)) {
+    if (Value.throttled) {
+      Actions.warning('Throttled: ' + Key)
+    }
+  }
+
+  Actions.startGroup('GetCDNResponse called: ' + ID)
+  Actions.info(JSON.stringify(ResponseParsed))
+  Actions.endGroup()
+  return ResponseParsed
+}
+
+async function PostPurgeRequest(
+  Repo: string,
+  Tag: string[],
+  Filenames: string[],
+  BaseURL: URL
+): Promise<CDNPostResponseType> {
+  const ResponseParsed = await RequestJSON(
+    new URL('/', BaseURL),
+    CDNPostResponseSchema,
+    {
+      HttpMethod: 'POST',
+      Payload: JSON.stringify({
+        path: CreatePurgePaths(Repo, Tag, Filenames)
+      }),
+      HttpHeaders: {
+        'cache-control': 'no-cache',
+        'content-type': 'application/json'
+      }
+    }
+  )
+
+  Actions.startGroup('PostPurgeRequest called: ' + ResponseParsed.id)
+  Actions.info(JSON.stringify(ResponseParsed))
+  Actions.endGroup()
+  return ResponseParsed
+}
+
+async function WaitForPurgeCompletion(
+  ID: string,
+  BaseURL: URL,
+  PollIntervalMs: number
+): Promise<CDNStatusResponseType> {
+  while (true) {
+    const Response = await GetCDNResponse(ID, BaseURL)
+
+    if (Response.status !== 'pending') {
+      return Response
+    }
+
+    await Sleep(PollIntervalMs)
+  }
 }
 
 export class PurgeRequestManager {
-	private readonly SharedPLimit = PLimit(Os.cpus().length)
-	private readonly RemainingFilenames: RemainingFilenamesArrayType[] = []
+  private readonly BaseURL: URL
+  private readonly PollIntervalMs: number
+  private readonly Concurrency: number
+  private readonly PendingGroups: RemainingFilenamesArrayType[][] = []
+  private readonly RemainingFilenames: RemainingFilenamesArrayType[] = []
 
-	constructor(private readonly Repo: string) {}
+  constructor(
+    private readonly Repo: string,
+    Options: IPurgeRequestManagerOptions = {}
+  ) {
+    this.BaseURL = CreateBaseURL(Options.BaseURL)
+    this.PollIntervalMs = Options.PollIntervalMs ?? 2500
+    this.Concurrency = Options.Concurrency ?? Os.availableParallelism()
+  }
 
-	AddURLs(Filenames: string[], Tag: string) {
-		const SplittedFilenames = ESToolkit.chunk(Filenames.map(Filename => ({Filename, Tag})), 20)
+  AddURLs(Filenames: string[], Tag: string): void {
+    const SplitFilenames = ESToolkit.chunk(
+      Filenames.map((Filename) => ({ Filename, Tag })),
+      20
+    )
 
-		if (SplittedFilenames[SplittedFilenames.length - 1].length < 20) {
-			this.RemainingFilenames.push(...SplittedFilenames.pop())
-		}
+    const LastChunk = SplitFilenames.at(-1)
 
-		for (const SplittedFilenameGroup of SplittedFilenames) {
-			void this.SharedPLimit(async () => {
-				const CDNRequestArary: CDNPostResponseType[] = []
-				while (CDNRequestArary.length === 0 || !CDNRequestArary.some(async CDNResponse => (await GetCDNResponse(CDNResponse.id)).status === 'finished'
-					|| (await GetCDNResponse(CDNResponse.id)).status === 'failed')) {
-					const CDNRequest: CDNPostResponseType = await PostPurgeRequest(this.Repo, new Array(20).fill(Tag, 0, 20) as string[], SplittedFilenameGroup.map(SplittedFilename => SplittedFilename.Filename))
-					CDNRequestArary.push(CDNRequest)
-					await new Promise(Resolve => {
-						setTimeout(Resolve, 2500)
-					})
-				}
+    if (LastChunk && LastChunk.length < 20) {
+      this.RemainingFilenames.push(...LastChunk)
+      SplitFilenames.pop()
+    }
 
-				Actions.info(`Queue: jsDelivr server returns that the following files are purged:
-				${SplittedFilenameGroup.map(Filename => `@${Filename.Tag}/${Filename.Filename}`).map(Item => `- ${Item}`).join('\n')}
-				`)
-			})
-		}
-	}
+    this.PendingGroups.push(...SplitFilenames)
+  }
 
-	Start(): void {
-		const RemainingFilenamesGroup = ESToolkit.chunk(this.RemainingFilenames, 20)
-		for (const RemainingFilenames of RemainingFilenamesGroup) {
-			void this.SharedPLimit(async () => {
-				const CDNRequestArary: CDNPostResponseType[] = []
-				while (CDNRequestArary.length === 0 || !CDNRequestArary.some(async CDNResponse => (await GetCDNResponse(CDNResponse.id)).status === 'finished'
-					|| (await GetCDNResponse(CDNResponse.id)).status === 'failed')) {
-					const CDNRequest: CDNPostResponseType = await PostPurgeRequest(this.Repo, RemainingFilenames.map(RemainingFilename => RemainingFilename.Tag), RemainingFilenames.map(RemainingFilename => RemainingFilename.Filename))
-					CDNRequestArary.push(CDNRequest)
-					await new Promise(Resolve => {
-						setTimeout(Resolve, 2500)
-					})
-				}
+  private DrainGroups(): RemainingFilenamesArrayType[][] {
+    const Groups = [
+      ...this.PendingGroups,
+      ...ESToolkit.chunk(this.RemainingFilenames, 20)
+    ].filter((Group) => Group.length > 0)
 
-				Actions.info('Queue: jsDelivr server returns that the following files are purged:')
-				Actions.info(`${RemainingFilenames.map(Filename => `@${Filename.Tag}/${Filename.Filename}`).map(Item => `- ${Item}`).join('\n')}`)
-			})
-		}
-	}
+    this.PendingGroups.length = 0
+    this.RemainingFilenames.length = 0
+    return Groups
+  }
+
+  private async ProcessGroup(Group: RemainingFilenamesArrayType[]): Promise<void> {
+    const Tags = Group.map((Filename) => Filename.Tag)
+    const Filenames = Group.map((Filename) => Filename.Filename)
+    const RequestResponse = await PostPurgeRequest(this.Repo, Tags, Filenames, this.BaseURL)
+    const StatusResponse = await WaitForPurgeCompletion(
+      RequestResponse.id,
+      this.BaseURL,
+      this.PollIntervalMs
+    )
+
+    if (StatusResponse.status !== 'finished') {
+      throw new Error('Purge request failed: ' + RequestResponse.id)
+    }
+
+    Actions.info(
+      'Queue: jsDelivr server returns that the following files are purged:\n' +
+      Group.map((Filename) => '- @' + Filename.Tag + '/' + Filename.Filename).join('\n')
+    )
+  }
+
+  async Start(): Promise<void> {
+    const AllGroups = this.DrainGroups()
+
+    if (AllGroups.length === 0) {
+      return
+    }
+
+    await RunWithConcurrency(AllGroups, this.Concurrency, async (Group) => {
+      await this.ProcessGroup(Group)
+    })
+  }
 }

--- a/sources/zip.ts
+++ b/sources/zip.ts
@@ -1,0 +1,106 @@
+import * as Zlib from 'node:zlib'
+
+const LocalFileHeaderSignature = 0x04034b50
+const CentralDirectoryHeaderSignature = 0x02014b50
+const EndOfCentralDirectorySignature = 0x06054b50
+
+type IZipCentralDirectoryEntry = {
+  Name: string
+  CompressionMethod: number
+  CompressedSize: number
+  UncompressedSize: number
+  LocalHeaderOffset: number
+}
+
+function FindEndOfCentralDirectoryOffset(ArchiveBuffer: Buffer): number {
+  const MinimumOffset = Math.max(0, ArchiveBuffer.length - 65557)
+
+  for (let Offset = ArchiveBuffer.length - 22; Offset >= MinimumOffset; Offset -= 1) {
+    if (ArchiveBuffer.readUInt32LE(Offset) === EndOfCentralDirectorySignature) {
+      return Offset
+    }
+  }
+
+  throw new Error('Invalid ZIP archive: end of central directory not found')
+}
+
+function ReadCentralDirectoryEntries(ArchiveBuffer: Buffer): IZipCentralDirectoryEntry[] {
+  const EndOfCentralDirectoryOffset = FindEndOfCentralDirectoryOffset(ArchiveBuffer)
+  const CentralDirectorySize = ArchiveBuffer.readUInt32LE(EndOfCentralDirectoryOffset + 12)
+  const CentralDirectoryOffset = ArchiveBuffer.readUInt32LE(EndOfCentralDirectoryOffset + 16)
+  const Entries: IZipCentralDirectoryEntry[] = []
+  const CentralDirectoryEnd = CentralDirectoryOffset + CentralDirectorySize
+  let Offset = CentralDirectoryOffset
+
+  while (Offset < CentralDirectoryEnd) {
+    if (ArchiveBuffer.readUInt32LE(Offset) !== CentralDirectoryHeaderSignature) {
+      throw new Error('Invalid ZIP archive: central directory header not found')
+    }
+
+    const CompressionMethod = ArchiveBuffer.readUInt16LE(Offset + 10)
+    const CompressedSize = ArchiveBuffer.readUInt32LE(Offset + 20)
+    const UncompressedSize = ArchiveBuffer.readUInt32LE(Offset + 24)
+    const FileNameLength = ArchiveBuffer.readUInt16LE(Offset + 28)
+    const ExtraFieldLength = ArchiveBuffer.readUInt16LE(Offset + 30)
+    const FileCommentLength = ArchiveBuffer.readUInt16LE(Offset + 32)
+    const LocalHeaderOffset = ArchiveBuffer.readUInt32LE(Offset + 42)
+    const FileNameStart = Offset + 46
+    const FileNameEnd = FileNameStart + FileNameLength
+    const Name = ArchiveBuffer.toString('utf8', FileNameStart, FileNameEnd)
+
+    Entries.push({
+      Name,
+      CompressionMethod,
+      CompressedSize,
+      UncompressedSize,
+      LocalHeaderOffset
+    })
+
+    Offset = FileNameEnd + ExtraFieldLength + FileCommentLength
+  }
+
+  return Entries
+}
+
+function ExtractCentralDirectoryEntry(
+  ArchiveBuffer: Buffer,
+  Entry: IZipCentralDirectoryEntry
+): Buffer {
+  if (ArchiveBuffer.readUInt32LE(Entry.LocalHeaderOffset) !== LocalFileHeaderSignature) {
+    throw new Error('Invalid ZIP archive: local file header missing for ' + Entry.Name)
+  }
+
+  const FileNameLength = ArchiveBuffer.readUInt16LE(Entry.LocalHeaderOffset + 26)
+  const ExtraFieldLength = ArchiveBuffer.readUInt16LE(Entry.LocalHeaderOffset + 28)
+  const DataOffset = Entry.LocalHeaderOffset + 30 + FileNameLength + ExtraFieldLength
+  const CompressedBuffer = ArchiveBuffer.subarray(DataOffset, DataOffset + Entry.CompressedSize)
+
+  if (Entry.CompressionMethod === 0) {
+    return Buffer.from(CompressedBuffer)
+  }
+
+  if (Entry.CompressionMethod === 8) {
+    const DecompressedBuffer = Zlib.inflateRawSync(CompressedBuffer)
+
+    if (Entry.UncompressedSize !== 0 && DecompressedBuffer.length !== Entry.UncompressedSize) {
+      throw new Error('Invalid ZIP archive: unexpected size for ' + Entry.Name)
+    }
+
+    return DecompressedBuffer
+  }
+
+  throw new Error('Unsupported ZIP compression method: ' + Entry.CompressionMethod)
+}
+
+export function ReadTextFromZipArchive(
+  ArchiveBuffer: Buffer,
+  Predicate: (EntryName: string) => boolean
+): string {
+  const Entry = ReadCentralDirectoryEntries(ArchiveBuffer).find((Item) => Predicate(Item.Name))
+
+  if (typeof Entry === 'undefined') {
+    throw new Error('ZIP entry not found')
+  }
+
+  return ExtractCentralDirectoryEntry(ArchiveBuffer, Entry).toString('utf8')
+}

--- a/tests/helpers/echo-server.ts
+++ b/tests/helpers/echo-server.ts
@@ -1,0 +1,94 @@
+import * as Http from 'node:http'
+import * as StreamConsumers from 'node:stream/consumers'
+
+export type IRecordedRequest = {
+  Method: string
+  URL: URL
+  Headers: Http.IncomingHttpHeaders
+  Body: Buffer
+}
+
+export type ITestServerResponse = {
+  StatusCode?: number
+  Headers?: Record<string, string>
+  Body?: Buffer | string | object
+}
+
+function NormalizeResponseBody(Body: ITestServerResponse['Body']): Buffer {
+  if (typeof Body === 'undefined') {
+    return Buffer.alloc(0)
+  }
+
+  if (Buffer.isBuffer(Body)) {
+    return Body
+  }
+
+  if (typeof Body === 'string') {
+    return Buffer.from(Body)
+  }
+
+  return Buffer.from(JSON.stringify(Body))
+}
+
+export async function CreateEchoServer(
+  Handler: (Request: IRecordedRequest) => Promise<ITestServerResponse> | ITestServerResponse
+): Promise<{
+  BaseURL: string
+  Requests: IRecordedRequest[]
+  Close: () => Promise<void>
+}> {
+  const Requests: IRecordedRequest[] = []
+  const Server = Http.createServer(async (IncomingMessage, ServerResponse) => {
+    const BodyArrayBuffer = await StreamConsumers.arrayBuffer(IncomingMessage)
+    const Request = {
+      Method: IncomingMessage.method ?? 'GET',
+      URL: new URL(
+        IncomingMessage.url ?? '/',
+        'http://' + (IncomingMessage.headers.host ?? '127.0.0.1')
+      ),
+      Headers: IncomingMessage.headers,
+      Body: Buffer.from(BodyArrayBuffer)
+    }
+
+    Requests.push(Request)
+
+    const Response = await Handler(Request)
+    const Headers = { ...(Response.Headers ?? {}) }
+
+    if (
+      typeof Response.Body === 'object' &&
+      Response.Body !== null &&
+      Buffer.isBuffer(Response.Body) === false &&
+      typeof Headers['content-type'] === 'undefined'
+    ) {
+      Headers['content-type'] = 'application/json'
+    }
+
+    ServerResponse.writeHead(Response.StatusCode ?? 200, Headers)
+    ServerResponse.end(NormalizeResponseBody(Response.Body))
+  })
+
+  await new Promise<void>((Resolve) => {
+    Server.listen(0, '127.0.0.1', () => {
+      Resolve()
+    })
+  })
+
+  const Address = Server.address()
+
+  if (Address === null || typeof Address === 'string') {
+    throw new Error('Failed to start local echo server')
+  }
+
+  return {
+    BaseURL: 'http://127.0.0.1:' + Address.port + '/',
+    Requests,
+    Close: async () => {
+      await new Promise<void>((Resolve) => {
+        Server.close(() => {
+          Resolve()
+        })
+      })
+    }
+  }
+}

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -1,0 +1,148 @@
+import * as Assert from 'node:assert/strict'
+import * as Zlib from 'node:zlib'
+import { test as Test } from 'node:test'
+import { HistoryManager, type IHistoryManagerGitHubClient } from '../sources/github.js'
+import { CreateEchoServer } from './helpers/echo-server.js'
+
+function CreateZipArchive(Entries: Record<string, string>): Buffer {
+  const LocalFileParts: Buffer[] = []
+  const CentralDirectoryParts: Buffer[] = []
+  let CurrentOffset = 0
+
+  for (const [EntryName, Content] of Object.entries(Entries)) {
+    const FileNameBuffer = Buffer.from(EntryName)
+    const PlainBuffer = Buffer.from(Content)
+    const CompressedBuffer = Zlib.deflateRawSync(PlainBuffer)
+    const LocalHeader = Buffer.alloc(30)
+    const CentralDirectoryHeader = Buffer.alloc(46)
+
+    LocalHeader.writeUInt32LE(0x04034b50, 0)
+    LocalHeader.writeUInt16LE(20, 4)
+    LocalHeader.writeUInt16LE(0, 6)
+    LocalHeader.writeUInt16LE(8, 8)
+    LocalHeader.writeUInt16LE(0, 10)
+    LocalHeader.writeUInt16LE(0, 12)
+    LocalHeader.writeUInt32LE(0, 14)
+    LocalHeader.writeUInt32LE(CompressedBuffer.length, 18)
+    LocalHeader.writeUInt32LE(PlainBuffer.length, 22)
+    LocalHeader.writeUInt16LE(FileNameBuffer.length, 26)
+    LocalHeader.writeUInt16LE(0, 28)
+
+    CentralDirectoryHeader.writeUInt32LE(0x02014b50, 0)
+    CentralDirectoryHeader.writeUInt16LE(20, 4)
+    CentralDirectoryHeader.writeUInt16LE(20, 6)
+    CentralDirectoryHeader.writeUInt16LE(0, 8)
+    CentralDirectoryHeader.writeUInt16LE(8, 10)
+    CentralDirectoryHeader.writeUInt16LE(0, 12)
+    CentralDirectoryHeader.writeUInt16LE(0, 14)
+    CentralDirectoryHeader.writeUInt32LE(0, 16)
+    CentralDirectoryHeader.writeUInt32LE(CompressedBuffer.length, 20)
+    CentralDirectoryHeader.writeUInt32LE(PlainBuffer.length, 24)
+    CentralDirectoryHeader.writeUInt16LE(FileNameBuffer.length, 28)
+    CentralDirectoryHeader.writeUInt16LE(0, 30)
+    CentralDirectoryHeader.writeUInt16LE(0, 32)
+    CentralDirectoryHeader.writeUInt16LE(0, 34)
+    CentralDirectoryHeader.writeUInt16LE(0, 36)
+    CentralDirectoryHeader.writeUInt32LE(0, 38)
+    CentralDirectoryHeader.writeUInt32LE(CurrentOffset, 42)
+
+    const LocalPart = Buffer.concat([LocalHeader, FileNameBuffer, CompressedBuffer])
+    LocalFileParts.push(LocalPart)
+    CentralDirectoryParts.push(Buffer.concat([CentralDirectoryHeader, FileNameBuffer]))
+    CurrentOffset += LocalPart.length
+  }
+
+  const CentralDirectory = Buffer.concat(CentralDirectoryParts)
+  const EndOfCentralDirectory = Buffer.alloc(22)
+  const EntryCount = Object.keys(Entries).length
+
+  EndOfCentralDirectory.writeUInt32LE(0x06054b50, 0)
+  EndOfCentralDirectory.writeUInt16LE(0, 4)
+  EndOfCentralDirectory.writeUInt16LE(0, 6)
+  EndOfCentralDirectory.writeUInt16LE(EntryCount, 8)
+  EndOfCentralDirectory.writeUInt16LE(EntryCount, 10)
+  EndOfCentralDirectory.writeUInt32LE(CentralDirectory.length, 12)
+  EndOfCentralDirectory.writeUInt32LE(CurrentOffset, 16)
+  EndOfCentralDirectory.writeUInt16LE(0, 20)
+
+  return Buffer.concat([...LocalFileParts, CentralDirectory, EndOfCentralDirectory])
+}
+
+Test('HistoryManager downloads and parses the latest local dist-tag artifact', async () => {
+  const ArchiveBuffer = CreateZipArchive({
+    'artifact/dist-tag.json': '{"latest":"2.0.0"}'
+  })
+
+  const Server = await CreateEchoServer((Request) => {
+    if (Request.URL.pathname === '/artifacts/dist-tag.zip') {
+      return {
+        Headers: {
+          'content-type': 'application/zip'
+        },
+        Body: ArchiveBuffer
+      }
+    }
+
+    return {
+      StatusCode: 404,
+      Body: 'not found'
+    }
+  })
+
+  const GitHubClient: IHistoryManagerGitHubClient = {
+    actions: {
+      listWorkflowRunsForRepo: async () => ({
+        data: {
+          workflow_runs: [
+            {
+              id: 1,
+              status: 'completed',
+              conclusion: 'success',
+              updated_at: '2026-04-04T10:00:00Z'
+            },
+            {
+              id: 2,
+              status: 'completed',
+              conclusion: 'success',
+              updated_at: '2026-04-04T12:00:00Z'
+            },
+            {
+              id: 3,
+              status: 'completed',
+              conclusion: 'failure',
+              updated_at: '2026-04-04T13:00:00Z'
+            }
+          ]
+        }
+      }),
+      listWorkflowRunArtifacts: async (Parameters) => ({
+        data: {
+          artifacts: Parameters.run_id === 2
+            ? [{
+              name: 'dist-tag',
+              archive_download_url: Server.BaseURL + 'artifacts/dist-tag.zip'
+            }]
+            : []
+        }
+      })
+    }
+  }
+
+  try {
+    const History = await new HistoryManager(
+      {
+        Repo: 'owner/repo',
+        GitHubToken: 'token',
+        WorkflowRef: 'owner/repo/.github/workflows/eslint.yml@refs/heads/main'
+      },
+      {
+        GitHubClient
+      }
+    ).RequestHistory()
+
+    Assert.deepEqual(History, { latest: '2.0.0' })
+    Assert.equal(Server.Requests[0]?.Headers.authorization, 'Bearer token')
+  } finally {
+    await Server.Close()
+  }
+})

--- a/tests/npm-file.test.ts
+++ b/tests/npm-file.test.ts
@@ -1,0 +1,151 @@
+import * as Assert from 'node:assert/strict'
+import * as Fs from 'node:fs/promises'
+import * as Os from 'node:os'
+import * as Path from 'node:path'
+import { test as Test } from 'node:test'
+import * as Tar from 'tar'
+import { FileManager } from '../sources/file.js'
+import { RequestNpmPackageMetaData } from '../sources/npm-api.js'
+import { CreateEchoServer } from './helpers/echo-server.js'
+
+async function CreateTemporaryDirectory(): Promise<string> {
+  return Fs.mkdtemp(Path.join(Os.tmpdir(), 'jsdelivr-purge-npm-'))
+}
+
+async function CreatePackageTarball(
+  ParentDirectory: string,
+  Files: Record<string, string>,
+  FileName: string
+): Promise<Buffer> {
+  const SourceDirectory = await CreateTemporaryDirectory()
+  const PackageDirectory = Path.join(SourceDirectory, 'package')
+  const TarballPath = Path.join(ParentDirectory, FileName)
+
+  await Fs.mkdir(PackageDirectory, { recursive: true })
+
+  for (const [RelativePath, Content] of Object.entries(Files)) {
+    const TargetPath = Path.join(PackageDirectory, RelativePath)
+    await Fs.mkdir(Path.dirname(TargetPath), { recursive: true })
+    await Fs.writeFile(TargetPath, Content)
+  }
+
+  await Tar.create({ cwd: SourceDirectory, gzip: true, file: TarballPath }, ['package'])
+  const TarballBuffer = await Fs.readFile(TarballPath)
+  await Fs.rm(SourceDirectory, { recursive: true, force: true })
+  return TarballBuffer
+}
+
+Test('RequestNpmPackageMetaData and FileManager use only local registry fixtures', async () => {
+  const TempDirectory = await CreateTemporaryDirectory()
+
+  try {
+    const CurrentTarball = await CreatePackageTarball(
+      TempDirectory,
+      {
+        'package.json': '{"name":"@scope/pkg"}',
+        'dist/index.js': 'export const Current = true\n'
+      },
+      'pkg-2.0.0.tgz'
+    )
+
+    const OlderTarball = await CreatePackageTarball(
+      TempDirectory,
+      {
+        'README.md': 'older readme\n',
+        'dist/index.js': 'export const Older = true\n'
+      },
+      'pkg-1.0.0.tgz'
+    )
+
+    const Server = await CreateEchoServer((Request) => {
+      const DecodedPathname = decodeURIComponent(Request.URL.pathname)
+
+      if (DecodedPathname === '/registry/@scope/pkg') {
+        return {
+          Body: {
+            name: '@scope/pkg',
+            'dist-tags': {
+              latest: '2.0.0'
+            },
+            versions: {
+              '1.0.0': {
+                name: '@scope/pkg',
+                version: '1.0.0',
+                dist: {
+                  shasum: 'one',
+                  tarball: 'http://example.test/pkg-1.0.0.tgz',
+                  integrity: 'sha512-one'
+                }
+              },
+              '2.0.0': {
+                name: '@scope/pkg',
+                version: '2.0.0',
+                dist: {
+                  shasum: 'two',
+                  tarball: 'http://example.test/pkg-2.0.0.tgz',
+                  integrity: 'sha512-two'
+                }
+              }
+            },
+            time: {
+              created: '2026-04-04T00:00:00Z',
+              modified: '2026-04-04T00:00:00Z',
+              '1.0.0': '2026-04-03T00:00:00Z',
+              '2.0.0': '2026-04-04T00:00:00Z'
+            }
+          }
+        }
+      }
+
+      if (DecodedPathname === '/registry/@scope/pkg/-/pkg-2.0.0.tgz') {
+        return {
+          Headers: {
+            'content-type': 'application/octet-stream'
+          },
+          Body: CurrentTarball
+        }
+      }
+
+      if (DecodedPathname === '/registry/@scope/pkg/-/pkg-1.0.0.tgz') {
+        return {
+          Headers: {
+            'content-type': 'application/octet-stream'
+          },
+          Body: OlderTarball
+        }
+      }
+
+      return {
+        StatusCode: 404,
+        Body: 'not found'
+      }
+    })
+
+    try {
+      const Metadata = await RequestNpmPackageMetaData('@scope/pkg', {
+        RegistryBaseURL: Server.BaseURL + 'registry/'
+      })
+
+      Assert.equal(Metadata['dist-tags'].latest, '2.0.0')
+      Assert.equal(
+        decodeURIComponent(Server.Requests[0]?.URL.pathname.replace('/registry/', '') ?? ''),
+        '@scope/pkg'
+      )
+
+      const Files = await new FileManager(
+        '@scope/pkg',
+        { A: '2.0.0', B: '1.0.0' },
+        Path.join(TempDirectory, 'workspace'),
+        {
+          RegistryBaseURL: Server.BaseURL + 'registry/'
+        }
+      ).Union()
+
+      Assert.deepEqual(Files.toSorted(), ['README.md', 'dist/index.js', 'package.json'].toSorted())
+    } finally {
+      await Server.Close()
+    }
+  } finally {
+    await Fs.rm(TempDirectory, { recursive: true, force: true })
+  }
+})

--- a/tests/requests.test.ts
+++ b/tests/requests.test.ts
@@ -1,0 +1,79 @@
+import * as Assert from 'node:assert/strict'
+import { test as Test } from 'node:test'
+import { PurgeRequestManager } from '../sources/requests.js'
+import { CreateEchoServer } from './helpers/echo-server.js'
+
+Test('PurgeRequestManager batches requests and polls the local status server', async () => {
+  const PostedPaths = new Map<string, string[]>()
+  const PollCountByID = new Map<string, number>()
+  let NextID = 1
+
+  const Server = await CreateEchoServer((Request) => {
+    if (Request.Method === 'POST' && Request.URL.pathname === '/') {
+      const Payload = JSON.parse(Request.Body.toString()) as Record<string, string[]>
+      const ID = 'request-' + NextID
+      NextID += 1
+      PostedPaths.set(ID, Payload.path ?? [])
+      PollCountByID.set(ID, 0)
+
+      return {
+        Body: {
+          id: ID,
+          status: 'pending',
+          timestamp: '2026-04-04T00:00:00Z'
+        }
+      }
+    }
+
+    if (Request.Method === 'GET' && Request.URL.pathname.startsWith('/status/')) {
+      const ID = Request.URL.pathname.split('/').at(-1) ?? ''
+      const Count = (PollCountByID.get(ID) ?? 0) + 1
+      const Paths = PostedPaths.get(ID) ?? []
+
+      PollCountByID.set(ID, Count)
+
+      return {
+        Body: {
+          id: ID,
+          status: Count >= 2 ? 'finished' : 'pending',
+          paths: Object.fromEntries(Paths.map((Pathname) => [Pathname, {
+            throttled: false,
+            providers: {
+              CF: true,
+              FY: true
+            }
+          }]))
+        }
+      }
+    }
+
+    return {
+      StatusCode: 404,
+      Body: 'not found'
+    }
+  })
+
+  try {
+    const Files = Array.from({ length: 21 }, (UnusedValue, Index) => 'dist/file-' + String(Index + 1) + '.js')
+    const Manager = new PurgeRequestManager('@scope/pkg', {
+      BaseURL: Server.BaseURL,
+      PollIntervalMs: 10,
+      Concurrency: 1
+    })
+
+    Manager.AddURLs(Files, 'latest')
+    await Manager.Start()
+
+    const PostRequests = Server.Requests.filter((Request) => Request.Method === 'POST')
+    const FirstPayload = JSON.parse(PostRequests[0]?.Body.toString() ?? '{}') as Record<string, string[]>
+    const SecondPayload = JSON.parse(PostRequests[1]?.Body.toString() ?? '{}') as Record<string, string[]>
+
+    Assert.equal(PostRequests.length, 2)
+    Assert.equal((FirstPayload.path ?? []).length, 20)
+    Assert.equal((SecondPayload.path ?? []).length, 1)
+    Assert.equal(FirstPayload.path?.[0], '/npm/@scope/pkg@latest/dist/file-1.js')
+    Assert.equal(SecondPayload.path?.[0], '/npm/@scope/pkg@latest/dist/file-21.js')
+  } finally {
+    await Server.Close()
+  }
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,14 +2,16 @@
   "compilerOptions": {
     "outDir": "dist",
     "module": "NodeNext",
-    "target": "ES2022",
+    "target": "ES2024",
     "moduleResolution": "NodeNext",
     "removeComments": true,
     "alwaysStrict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "include": [
     "index.ts",
-    "sources/**/*.ts"
+    "sources/**/*.ts",
+    "tests/**/*.ts"
   ]
 }


### PR DESCRIPTION
- Add http.ts for handling HTTP requests with SimpleSecureReq.
- Implement functions for creating default headers, request options, and ensuring success status codes.
- Add RequestExpectedAs, RequestJSON, and RequestBuffer functions for making requests and parsing responses.

refactor: update npm API to use new HTTP request handling

- Replace Got with RequestJSON in npm-api.ts for fetching package metadata.
- Define Zod schemas for package metadata and version metadata.
- Implement utility functions for encoding package names and creating registry URLs.

refactor: enhance requests handling with structured responses

- Update requests.ts to use RequestJSON for CDN status and purge requests.
- Implement polling for purge request completion and concurrency handling.
- Refactor PurgeRequestManager to manage batch requests and status polling.

feat: add ZIP archive reading capabilities

- Introduce zip.ts for reading text from ZIP archives.
- Implement functions for extracting central directory entries and reading text from ZIP files.

test: add tests for history manager and npm package metadata requests

- Create echo server for simulating HTTP responses in tests.
- Implement tests for HistoryManager to validate artifact downloads and parsing.
- Add tests for RequestNpmPackageMetaData and FileManager to ensure correct behavior with local registry fixtures.

test: add requests manager tests for batching and polling

- Implement tests for PurgeRequestManager to validate request batching and polling behavior.

chore: update TypeScript configuration

- Change target from ES2022 to ES2024 and include test files in tsconfig.json.